### PR TITLE
Add ease in/out balance to "auto" cycler

### DIFF
--- a/src/components/automations/Cycler.tsx
+++ b/src/components/automations/Cycler.tsx
@@ -115,25 +115,22 @@ const Cycler = ({
             let cycleValue: number;
             if (longAfterFinish) cycleValue = 1.0;
             else {
-                const trshold = (options.easeInLength/100);
-                let inMul, outMul : number;
+                const threshold = options.easeInLength / 100;
+                let inMul, outMul: number;
                 // Corner cases that would otherwise give us div by zero errors
-                if (trshold === 0)
-                {
-                    inMul = 0; outMul = 1;
-                }
-                else if (trshold === 1)
-                {
-                    inMul = 1; outMul = 0;
-                }
-                else
-                {
-                    inMul = Math.pow(trshold, -1);
-                    outMul = Math.pow(1-trshold, -1);
+                if (threshold === 0) {
+                    inMul = 0;
+                    outMul = 1;
+                } else if (threshold === 1) {
+                    inMul = 1;
+                    outMul = 0;
+                } else {
+                    inMul = Math.pow(threshold, -1);
+                    outMul = Math.pow(1 - threshold, -1);
                 }
 
-                if (cycleX < trshold) cycleValue = easeIn(cycleX * inMul);
-                else cycleValue = afterFinish ? 1.0 : easeOut((cycleX - trshold) * outMul);
+                if (cycleX < threshold) cycleValue = easeIn(cycleX * inMul);
+                else cycleValue = afterFinish ? 1.0 : easeOut((cycleX - threshold) * outMul);
             }
 
             //console.log({options, afterFinish, longAfterFinish, cycleX, cycleValue});

--- a/src/components/automations/Cycler.tsx
+++ b/src/components/automations/Cycler.tsx
@@ -9,6 +9,7 @@ export interface CyclerOptions {
     cycleDuration: number;
     sessionDuration: number;
     setSpeedInterval: number;
+    easeInLength: number;
 }
 
 const Cycler = ({
@@ -19,6 +20,7 @@ const Cycler = ({
         cycleDuration: 60,
         sessionDuration: 0,
         setSpeedInterval: 0.5,
+        easeInLength: 50,
     },
     onSpeedChanged,
 }: {
@@ -113,8 +115,25 @@ const Cycler = ({
             let cycleValue: number;
             if (longAfterFinish) cycleValue = 1.0;
             else {
-                if (cycleX < 0.5) cycleValue = easeIn(cycleX * 2);
-                else cycleValue = afterFinish ? 1.0 : easeOut((cycleX - 0.5) * 2);
+                const trshold = (options.easeInLength/100);
+                let inMul, outMul : number;
+                // Corner cases that would otherwise give us div by zero errors
+                if (trshold === 0)
+                {
+                    inMul = 0; outMul = 1;
+                }
+                else if (trshold === 1)
+                {
+                    inMul = 1; outMul = 0;
+                }
+                else
+                {
+                    inMul = Math.pow(trshold, -1);
+                    outMul = Math.pow(1-trshold, -1);
+                }
+
+                if (cycleX < trshold) cycleValue = easeIn(cycleX * inMul);
+                else cycleValue = afterFinish ? 1.0 : easeOut((cycleX - trshold) * outMul);
             }
 
             //console.log({options, afterFinish, longAfterFinish, cycleX, cycleValue});

--- a/src/lib/CHANGELOG.ts
+++ b/src/lib/CHANGELOG.ts
@@ -1,5 +1,15 @@
 //there has to be a better way than this... :I
 const changelog = `
+## v0.9.0
+
+### 30th June 2021
+
+#### Added
+
+  * The Cycler now has an ease in / ease out balance slider to control the length and midpoint of the speed curves
+
+---
+
 ## v0.8.0
 
 ### 26th May 2021

--- a/src/pages/Auto.tsx
+++ b/src/pages/Auto.tsx
@@ -13,6 +13,7 @@ const Auto = () => {
         cycleDuration: 60,
         sessionDuration: 0,
         setSpeedInterval: 0.5,
+        easeInLength: 50,
     });
     const [speed, setSpeed] = useState(0);
 
@@ -101,6 +102,19 @@ const Auto = () => {
                             onChange={handleChange}
                         />
                         <p>{data.setSpeedInterval} sec</p>
+                    </div>
+                    <div className={style.control}>
+                        <label htmlFor="easeInLength">Ease In/Out Balance</label>
+                        <input
+                            type="range"
+                            id="easeInLength"
+                            min="0"
+                            max="100"
+                            step="1"
+                            value={data.easeInLength}
+                            onChange={handleChange}
+                        />
+                        <p>{data.easeInLength}%</p>
                     </div>
                     <button onClick={() => setEnabled(!enabled)}>
                         {enabled ? "Stop Session" : "Start Session"}


### PR DESCRIPTION
Adds a 0%-100% slider to the cycler, which moves the point at which the
cycler transitions from easing in, to easing out (ergo, moves the point
of maximum speed during the cycle). This implementation maintains the
current exponential ease in/out curves, but determines their length
dynamically depending on the position of that midpoint.

---

Mostly just wanted this myself, figured I'd kick a PR up in case it interests you.